### PR TITLE
Add interactive language tutor web app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,27 @@
-- 👋 Hi, I’m @renenovillo
-- 👀 I’m interested in Business & Marketing analytics
-- 🌱 I’m currently learning Python and R
-- 💞️ I’m looking to collaborate on cool projects
-- 📫 How to reach me: twitter: @renenovillo
+# Language Tutor Web App
 
-<!---
-renenovillo/renenovillo is a ✨ special ✨ repository because its `README.md` (this file) appears on your GitHub profile.
-You can click the Preview link to take a look at your changes.
---->
+Esta aplicación web ofrece un tutor interactivo para el aprendizaje de idiomas utilizando un modelo de lenguaje avanzado.
+
+## Características
+- Selección de idioma (inglés, francés, alemán, portugués).
+- Conversaciones naturales con el tutor en el idioma elegido.
+- Retroalimentación gramatical en tiempo real.
+- Objetivos de aprendizaje personalizables.
+- Seguimiento de progreso con barras de avance y diario de la sesión.
+- Modo de chat casual o lección estructurada.
+
+## Requisitos
+- Node.js 18+
+- Variable de entorno `OPENAI_API_KEY` con una clave válida (opcional, para obtener respuestas reales del LLM).
+
+## Uso
+```bash
+npm start
+```
+Abra su navegador en [http://localhost:3000](http://localhost:3000) para usar la aplicación.
+
+## Tests
+No se incluyen pruebas automatizadas. Ejecuta el comando siguiente para confirmar:
+```bash
+npm test
+```

--- a/package.json
+++ b/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "rene",
+  "version": "1.0.0",
+  "description": "Interactive language learning tutor web app",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js",
+    "test": "echo 'No tests specified'"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs"
+}

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <title>Language Tutor</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="app">
+    <header>
+      <h1>Tutor de Idiomas</h1>
+      <select id="language">
+        <option value="English">English</option>
+        <option value="French">Français</option>
+        <option value="German">Deutsch</option>
+        <option value="Portuguese">Português</option>
+      </select>
+      <button id="modeToggle">Lección estructurada</button>
+      <span id="proficiency" class="proficiency">Beginner</span>
+    </header>
+    <main>
+      <div id="conversation" class="conversation"></div>
+      <aside class="sidebar">
+        <section>
+          <h2>Retroalimentación</h2>
+          <div id="feedback"></div>
+        </section>
+        <section>
+          <h2>Objetivos</h2>
+          <ul id="objectives"></ul>
+          <input id="newObjective" placeholder="Nuevo objetivo">
+          <button id="addObjective">Añadir</button>
+        </section>
+        <section>
+          <h2>Progreso</h2>
+          <label>Vocabulario</label>
+          <div class="bar"><div id="vocabBar" class="bar-inner"></div></div>
+          <label>Gramática</label>
+          <div class="bar"><div id="grammarBar" class="bar-inner"></div></div>
+          <label>Conversación</label>
+          <div class="bar"><div id="timeBar" class="bar-inner"></div></div>
+          <div id="errors"></div>
+        </section>
+        <section>
+          <h2>Diario</h2>
+          <div id="diary"></div>
+        </section>
+      </aside>
+    </main>
+    <footer>
+      <form id="chatForm">
+        <input id="message" autocomplete="off" placeholder="Escribe un mensaje" />
+        <button>Enviar</button>
+      </form>
+    </footer>
+  </div>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/public/script.js
+++ b/public/script.js
@@ -1,0 +1,137 @@
+const conversationEl = document.getElementById('conversation');
+const feedbackEl = document.getElementById('feedback');
+const objectivesEl = document.getElementById('objectives');
+const newObjectiveEl = document.getElementById('newObjective');
+const addObjectiveBtn = document.getElementById('addObjective');
+const vocabBar = document.getElementById('vocabBar');
+const grammarBar = document.getElementById('grammarBar');
+const timeBar = document.getElementById('timeBar');
+const errorsEl = document.getElementById('errors');
+const diaryEl = document.getElementById('diary');
+const proficiencyEl = document.getElementById('proficiency');
+const modeToggle = document.getElementById('modeToggle');
+const languageSelect = document.getElementById('language');
+
+let mode = 'chat';
+let objectives = [];
+let conversation = [];
+let vocab = new Set();
+let mistakes = 0;
+let errorTracker = {};
+let startTime = Date.now();
+let diary = [];
+
+function appendMessage(who, text) {
+  const div = document.createElement('div');
+  div.className = `msg ${who}`;
+  div.textContent = text;
+  conversationEl.appendChild(div);
+  conversationEl.scrollTop = conversationEl.scrollHeight;
+  diary.push({ type: who, text });
+  updateDiary();
+}
+
+function showFeedback(text) {
+  feedbackEl.textContent = text;
+  if (/error|mistake|incorrect|intenta|try/i.test(text)) {
+    mistakes++;
+    errorTracker[text] = (errorTracker[text] || 0) + 1;
+    updateErrors();
+  }
+}
+
+function updateErrors() {
+  const entries = Object.entries(errorTracker).map(([msg, count]) => `<div>${msg} (${count})</div>`);
+  errorsEl.innerHTML = entries.join('');
+}
+
+function vocabAdd(text) {
+  text.split(/\s+/).forEach(w => vocab.add(w.toLowerCase()));
+}
+
+function updateProgress() {
+  vocabBar.style.width = Math.min(vocab.size, 100) + '%';
+  const grammarScore = Math.max(0, 100 - mistakes * 10);
+  grammarBar.style.width = grammarScore + '%';
+  const elapsed = (Date.now() - startTime) / 1000;
+  timeBar.style.width = Math.min(100, (elapsed / 600) * 100) + '%';
+}
+
+function suggestObjectives(level) {
+  if (level === 'Beginner') return ['Aprender saludos básicos', 'Practicar verbos en presente', 'Ampliar vocabulario de comida'];
+  if (level === 'Intermediate') return ['Dominar verbos irregulares', 'Mejorar estructura de oraciones', 'Hablar sobre eventos pasados'];
+  return ['Practicar modismos', 'Debatir temas complejos', 'Refinar pronunciación'];
+}
+
+function updateObjectivesDisplay() {
+  objectivesEl.innerHTML = '';
+  objectives.forEach((obj, idx) => {
+    const li = document.createElement('li');
+    li.textContent = obj;
+    li.contentEditable = true;
+    li.addEventListener('input', e => {
+      objectives[idx] = e.target.textContent;
+    });
+    objectivesEl.appendChild(li);
+  });
+}
+
+addObjectiveBtn.addEventListener('click', () => {
+  const val = newObjectiveEl.value.trim();
+  if (!val) return;
+  objectives.push(val);
+  newObjectiveEl.value = '';
+  updateObjectivesDisplay();
+});
+
+modeToggle.addEventListener('click', () => {
+  mode = mode === 'chat' ? 'lesson' : 'chat';
+  modeToggle.textContent = mode === 'chat' ? 'Lección estructurada' : 'Chat casual';
+});
+
+function updateProficiency() {
+  const level = mistakes < 3 ? 'Intermediate' : 'Beginner';
+  proficiencyEl.textContent = level;
+}
+
+function updateDiary() {
+  diaryEl.innerHTML = diary.map(entry => `<div class="${entry.type}"><strong>${entry.type === 'user' ? 'Tú' : 'Tutor'}:</strong> ${entry.text}</div>`).join('');
+}
+
+// initialize objectives
+objectives = suggestObjectives('Beginner');
+updateObjectivesDisplay();
+
+const form = document.getElementById('chatForm');
+form.addEventListener('submit', async e => {
+  e.preventDefault();
+  const messageInput = document.getElementById('message');
+  const text = messageInput.value.trim();
+  if (!text) return;
+  const language = languageSelect.value;
+  appendMessage('user', text);
+  vocabAdd(text);
+  const messagesForServer = [
+    { role: 'system', content: `Learning objectives: ${objectives.join(', ')}. Mode: ${mode}.` },
+    ...conversation,
+    { role: 'user', content: text }
+  ];
+  try {
+    const res = await fetch('/api/chat', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ language, messages: messagesForServer })
+    });
+    const data = await res.json();
+    appendMessage('tutor', data.reply);
+    showFeedback(data.feedback || '');
+    conversation.push({ role: 'user', content: text });
+    conversation.push({ role: 'assistant', content: data.reply });
+    updateProficiency();
+    updateProgress();
+  } catch (err) {
+    appendMessage('tutor', 'Error contacting server.');
+  }
+  messageInput.value = '';
+});
+

--- a/public/style.css
+++ b/public/style.css
@@ -1,0 +1,20 @@
+html, body { height: 100%; margin: 0; font-family: Arial, sans-serif; }
+.app { display: flex; flex-direction: column; height: 100%; }
+header { display: flex; align-items: center; gap: 1rem; padding: 0.5rem 1rem; background: #4a90e2; color: #fff; }
+main { flex: 1; display: flex; overflow: hidden; }
+.conversation { flex: 2; padding: 1rem; overflow-y: auto; border-right: 1px solid #ddd; }
+.conversation .msg { margin: 0.5rem 0; }
+.conversation .user { text-align: right; }
+.sidebar { flex: 1; padding: 1rem; overflow-y: auto; background: #f7f7f7; }
+.sidebar section { margin-bottom: 1rem; }
+.bar { background: #e0e0e0; width: 100%; height: 10px; margin-bottom: 0.5rem; }
+.bar-inner { background: #4a90e2; height: 100%; width: 0%; }
+footer { border-top: 1px solid #ddd; padding: 0.5rem; }
+#chatForm { display: flex; gap: 0.5rem; }
+#chatForm input { flex: 1; padding: 0.5rem; }
+#chatForm button { padding: 0.5rem 1rem; }
+.proficiency { margin-left: auto; font-weight: bold; }
+@media (max-width: 768px) {
+  main { flex-direction: column; }
+  .conversation { border-right: none; border-bottom: 1px solid #ddd; }
+}

--- a/server.js
+++ b/server.js
@@ -1,0 +1,108 @@
+const http = require('http');
+const fs = require('fs');
+const path = require('path');
+
+const publicDir = path.join(__dirname, 'public');
+
+function serveStatic(res, filePath, contentType) {
+  fs.readFile(filePath, (err, data) => {
+    if (err) {
+      res.writeHead(404);
+      res.end('Not found');
+    } else {
+      res.writeHead(200, { 'Content-Type': contentType });
+      res.end(data);
+    }
+  });
+}
+
+async function generateResponse(language, messages) {
+  const apiKey = process.env.OPENAI_API_KEY;
+  if (!apiKey) {
+    return {
+      reply: `[${language}] API key missing. Placeholder response.`,
+      feedback: 'Set OPENAI_API_KEY to enable LLM responses.'
+    };
+  }
+
+  const system = `You are a helpful language tutor that converses in ${language}.`;
+  const payload = {
+    model: 'gpt-3.5-turbo',
+    messages: [{ role: 'system', content: system }, ...messages]
+  };
+
+  const completion = await fetch('https://api.openai.com/v1/chat/completions', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${apiKey}`
+    },
+    body: JSON.stringify(payload)
+  });
+  const data = await completion.json();
+  const reply = data?.choices?.[0]?.message?.content || '';
+
+  const fbPrompt = `Provide grammar, vocabulary and syntax feedback for the following sentence in ${language}: ${messages[messages.length - 1].content}`;
+  const fbPayload = {
+    model: 'gpt-3.5-turbo',
+    messages: [
+      { role: 'system', content: 'You are a language teacher offering concise feedback.' },
+      { role: 'user', content: fbPrompt }
+    ]
+  };
+  const fbCompletion = await fetch('https://api.openai.com/v1/chat/completions', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${apiKey}`
+    },
+    body: JSON.stringify(fbPayload)
+  });
+  const fbData = await fbCompletion.json();
+  const feedback = fbData?.choices?.[0]?.message?.content?.trim() || '';
+
+  return { reply, feedback };
+}
+
+const server = http.createServer((req, res) => {
+  if (req.method === 'GET') {
+    const url = req.url === '/' ? '/index.html' : req.url;
+    const ext = path.extname(url);
+    const contentTypes = {
+      '.html': 'text/html',
+      '.js': 'application/javascript',
+      '.css': 'text/css'
+    };
+    const filePath = path.join(publicDir, url);
+    if (contentTypes[ext]) {
+      serveStatic(res, filePath, contentTypes[ext]);
+    } else {
+      res.writeHead(404);
+      res.end();
+    }
+  } else if (req.method === 'POST' && req.url === '/api/chat') {
+    let body = '';
+    req.on('data', chunk => {
+      body += chunk.toString();
+    });
+    req.on('end', async () => {
+      try {
+        const { language, messages } = JSON.parse(body);
+        const result = await generateResponse(language, messages);
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify(result));
+      } catch (err) {
+        res.writeHead(500, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ error: 'Server error', details: err.message }));
+      }
+    });
+  } else {
+    res.writeHead(404);
+    res.end();
+  }
+});
+
+const PORT = process.env.PORT || 3000;
+server.listen(PORT, () => {
+  console.log(`Server listening on http://localhost:${PORT}`);
+});


### PR DESCRIPTION
## Summary
- add Node.js server that proxies requests to OpenAI and serves static assets
- build responsive client UI with language selector, feedback panel, objectives and progress tracking
- document setup, usage and testing instructions

## Testing
- `npm test`
- `npm start` (server launched)


------
https://chatgpt.com/codex/tasks/task_e_6897e28497808321b8f71e0d8359b590